### PR TITLE
fix: migration issues on `pgx.ErrNoRows`

### DIFF
--- a/api/v1/server/handlers/tenants/create.go
+++ b/api/v1/server/handlers/tenants/create.go
@@ -32,13 +32,13 @@ func (t *TenantService) TenantCreate(ctx echo.Context, request gen.TenantCreateR
 	}
 
 	// determine if a tenant with the slug already exists
-	existingTenant, err := t.config.APIRepository.Tenant().GetTenantBySlug(ctx.Request().Context(), request.Body.Slug)
+	_, err := t.config.APIRepository.Tenant().GetTenantBySlug(ctx.Request().Context(), request.Body.Slug)
 
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, err
 	}
 
-	if existingTenant != nil {
+	if err == nil {
 		// just return bad request
 		return gen.TenantCreate400JSONResponse(
 			apierrors.NewAPIErrors("Tenant with the slug already exists."),

--- a/api/v1/server/handlers/users/create.go
+++ b/api/v1/server/handlers/users/create.go
@@ -36,13 +36,13 @@ func (u *UserService) UserCreate(ctx echo.Context, request gen.UserCreateRequest
 	}
 
 	// determine if the user exists before attempting to write the user
-	existingUser, err := u.config.APIRepository.User().GetUserByEmail(ctx.Request().Context(), string(request.Body.Email))
+	_, err := u.config.APIRepository.User().GetUserByEmail(ctx.Request().Context(), string(request.Body.Email))
 
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, err
 	}
 
-	if existingUser != nil {
+	if err == nil {
 		// just return bad request
 		return gen.UserCreate400JSONResponse(
 			apierrors.NewAPIErrors("Email is already registered."),

--- a/api/v1/server/handlers/users/get_current.go
+++ b/api/v1/server/handlers/users/get_current.go
@@ -21,13 +21,13 @@ func (u *UserService) UserGetCurrent(ctx echo.Context, request gen.UserGetCurren
 
 	var hasPass bool
 
-	pass, err := u.config.APIRepository.User().GetUserPassword(ctx.Request().Context(), userId)
+	_, err := u.config.APIRepository.User().GetUserPassword(ctx.Request().Context(), userId)
 
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, err
 	}
 
-	if pass != nil {
+	if err == nil {
 		hasPass = true
 	}
 

--- a/pkg/repository/postgres/workflow.go
+++ b/pkg/repository/postgres/workflow.go
@@ -463,16 +463,14 @@ func (r *workflowEngineRepository) CreateNewWorkflow(ctx context.Context, tenant
 	}
 
 	// preflight check to ensure the workflow doesn't already exist
-	workflow, err := r.queries.GetWorkflowByName(ctx, r.pool, dbsqlc.GetWorkflowByNameParams{
+	_, err := r.queries.GetWorkflowByName(ctx, r.pool, dbsqlc.GetWorkflowByNameParams{
 		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
 		Name:     opts.Name,
 	})
 
-	if err != nil {
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return nil, err
-		}
-	} else if workflow != nil {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	} else if err == nil {
 		return nil, fmt.Errorf(
 			"workflow with name '%s' already exists",
 			opts.Name,


### PR DESCRIPTION
# Description

Unlike the go prisma client, a `pgx.ErrNoRows` error from `sqlc` doesn't necessarily mean that the return value of the queried row is `nil`, instead it's a pointer to a zero-value of that struct. 

This fixes instances where the casing assumed that the queried row value was nil. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)