### PR TITLE
fix: check every 1s

### DIFF
--- a/internal/msgqueue/v1/rabbitmq/channel_pool.go
+++ b/internal/msgqueue/v1/rabbitmq/channel_pool.go
@@ -87,12 +87,13 @@ func newChannelPool(ctx context.Context, l *zerolog.Logger, url string) (*channe
 	// periodically check if the connection is still open
 	go func() {
 		retries := 0
+		ticker := time.NewTicker(1 * time.Second)
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
+			case <-ticker.C:
 			}
 
 			conn := p.getConnection()


### PR DESCRIPTION
# Description

Fixes cpu leak on loop to check rabbitMQ connection

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] check every 1s
