### PR TITLE
feat: cron and scheduled workflows

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -263,11 +263,12 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 	if sc.HasService("ticker") {
 		t, err := ticker.New(
 			ticker.WithMessageQueue(sc.MessageQueue),
+			ticker.WithMessageQueueV1(sc.MessageQueueV1),
 			ticker.WithRepository(sc.EngineRepository),
+			ticker.WithRepositoryV1(sc.V1),
 			ticker.WithLogger(sc.Logger),
 			ticker.WithTenantAlerter(sc.TenantAlerter),
 			ticker.WithEntitlementsRepository(sc.EntitlementRepository),
-			ticker.WithPartition(p),
 		)
 
 		if err != nil {
@@ -658,11 +659,12 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 
 		t, err := ticker.New(
 			ticker.WithMessageQueue(sc.MessageQueue),
+			ticker.WithMessageQueueV1(sc.MessageQueueV1),
 			ticker.WithRepository(sc.EngineRepository),
+			ticker.WithRepositoryV1(sc.V1),
 			ticker.WithLogger(sc.Logger),
 			ticker.WithTenantAlerter(sc.TenantAlerter),
 			ticker.WithEntitlementsRepository(sc.EntitlementRepository),
-			ticker.WithPartition(p),
 		)
 
 		if err != nil {

--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -115,41 +115,65 @@ func (t *TickerImpl) runCronWorkflow(tenantId, workflowVersionId, cron, cronPare
 
 		t.l.Debug().Msgf("ticker: running workflow %s", workflowVersionId)
 
+		tenant, err := t.repo.Tenant().GetTenantByID(ctx, tenantId)
+
+		if err != nil {
+			t.l.Error().Err(err).Msg("could not get tenant")
+			return
+		}
+
 		workflowVersion, err := t.repo.Workflow().GetWorkflowVersionById(ctx, tenantId, workflowVersionId)
 
 		if err != nil {
-			t.l.Err(err).Msg("could not get workflow version")
+			t.l.Error().Err(err).Msg("could not get workflow version")
 			return
 		}
-		// create a new workflow run in the database
-		createOpts, err := repository.GetCreateWorkflowRunOptsFromCron(cron, cronParentId, cronName, workflowVersion, input, additionalMetadata)
+
+		switch tenant.Version {
+		case dbsqlc.TenantMajorEngineVersionV0:
+			err = t.runCronWorkflowV0(ctx, tenantId, workflowVersion, cron, cronParentId, cronName, input, additionalMetadata)
+		case dbsqlc.TenantMajorEngineVersionV1:
+			err = t.runCronWorkflowV1(ctx, tenantId, workflowVersion, cron, cronParentId, cronName, input, additionalMetadata)
+		default:
+			t.l.Error().Msgf("unsupported tenant major engine version %s", tenant.Version)
+			return
+		}
 
 		if err != nil {
-			t.l.Err(err).Msg("could not get create workflow run opts")
-			return
+			t.l.Error().Err(err).Msg("could not run cron workflow")
 		}
-
-		workflowRun, err := t.repo.WorkflowRun().CreateNewWorkflowRun(ctx, tenantId, createOpts)
-
-		if err != nil {
-			t.l.Err(err).Msg("could not create workflow run")
-			return
-		}
-
-		workflowRunId := sqlchelpers.UUIDToStr(workflowRun.ID)
-
-		err = t.mq.AddMessage(
-			context.Background(),
-			msgqueue.WORKFLOW_PROCESSING_QUEUE,
-			tasktypes.WorkflowRunQueuedToTask(tenantId, workflowRunId),
-		)
-
-		if err != nil {
-			t.l.Err(err).Msg("could not add workflow run queued task")
-			return
-		}
-
 	}
+}
+
+func (t *TickerImpl) runCronWorkflowV0(ctx context.Context, tenantId string, workflowVersion *dbsqlc.GetWorkflowVersionForEngineRow, cron, cronParentId string, cronName *string, input []byte, additionalMetadata map[string]interface{}) error {
+	// create a new workflow run in the database
+	createOpts, err := repository.GetCreateWorkflowRunOptsFromCron(cron, cronParentId, cronName, workflowVersion, input, additionalMetadata)
+
+	if err != nil {
+		return fmt.Errorf("could not get create workflow run opts: %w", err)
+	}
+
+	workflowRun, err := t.repo.WorkflowRun().CreateNewWorkflowRun(ctx, tenantId, createOpts)
+
+	if err != nil {
+		t.l.Err(err).Msg("could not create workflow run")
+		return fmt.Errorf("could not create workflow run: %w", err)
+	}
+
+	workflowRunId := sqlchelpers.UUIDToStr(workflowRun.ID)
+
+	err = t.mq.AddMessage(
+		context.Background(),
+		msgqueue.WORKFLOW_PROCESSING_QUEUE,
+		tasktypes.WorkflowRunQueuedToTask(tenantId, workflowRunId),
+	)
+
+	if err != nil {
+		t.l.Err(err).Msg("could not add workflow run queued task")
+		return fmt.Errorf("could not add workflow run queued task: %w", err)
+	}
+
+	return nil
 }
 
 func (t *TickerImpl) handleCancelCron(ctx context.Context, key string) error {

--- a/internal/services/ticker/cron_v1.go
+++ b/internal/services/ticker/cron_v1.go
@@ -1,0 +1,55 @@
+package ticker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	msgqueuev1 "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
+	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
+)
+
+func (t *TickerImpl) runCronWorkflowV1(ctx context.Context, tenantId string, workflowVersion *dbsqlc.GetWorkflowVersionForEngineRow, cron, cronParentId string, cronName *string, input []byte, additionalMetadata map[string]interface{}) error {
+	var additionalMetaBytes []byte
+	var err error
+
+	if additionalMetadata != nil {
+		additionalMetaBytes, err = json.Marshal(additionalMetadata)
+
+		if err != nil {
+			return fmt.Errorf("could not marshal additional metadata: %w", err)
+		}
+	}
+
+	// send workflow run to task controller
+	opt := &v1.WorkflowNameTriggerOpts{
+		TriggerTaskData: &v1.TriggerTaskData{
+			WorkflowName:       workflowVersion.WorkflowName,
+			Data:               input,
+			AdditionalMetadata: additionalMetaBytes,
+		},
+		ExternalId: uuid.NewString(),
+		ShouldSkip: false,
+	}
+
+	msg, err := tasktypes.TriggerTaskMessage(
+		tenantId,
+		opt,
+	)
+
+	if err != nil {
+		return fmt.Errorf("could not create trigger task message: %w", err)
+	}
+
+	err = t.mqv1.SendMessage(ctx, msgqueuev1.TASK_PROCESSING_QUEUE, msg)
+
+	if err != nil {
+		return fmt.Errorf("could not send message to task queue: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -1,0 +1,44 @@
+package ticker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	msgqueuev1 "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
+	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
+)
+
+func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string, workflowVersion *dbsqlc.GetWorkflowVersionForEngineRow, scheduledWorkflowId string, scheduled *dbsqlc.PollScheduledWorkflowsRow) error {
+	// send workflow run to task controller
+	opt := &v1.WorkflowNameTriggerOpts{
+		TriggerTaskData: &v1.TriggerTaskData{
+			WorkflowName:       workflowVersion.WorkflowName,
+			Data:               scheduled.Input,
+			AdditionalMetadata: scheduled.AdditionalMetadata,
+		},
+		ExternalId: uuid.NewString(),
+		ShouldSkip: false,
+	}
+
+	msg, err := tasktypes.TriggerTaskMessage(
+		tenantId,
+		opt,
+	)
+
+	if err != nil {
+		return fmt.Errorf("could not create trigger task message: %w", err)
+	}
+
+	err = t.mqv1.SendMessage(ctx, msgqueuev1.TASK_PROCESSING_QUEUE, msg)
+
+	if err != nil {
+		return fmt.Errorf("could not send message to task queue: %w", err)
+	}
+
+	// delete the scheduled workflow
+	return t.repo.WorkflowRun().DeleteScheduledWorkflow(ctx, tenantId, scheduledWorkflowId)
+}

--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -31,7 +31,7 @@ type ConfigFile struct {
 
 	LogQueries bool `mapstructure:"logQueries" json:"logQueries,omitempty" default:"false"`
 
-	CacheDuration time.Duration `mapstructure:"cacheDuration" json:"cacheDuration,omitempty" default:"60s"`
+	CacheDuration time.Duration `mapstructure:"cacheDuration" json:"cacheDuration,omitempty" default:"5s"`
 }
 
 type SeedConfigFile struct {

--- a/pkg/repository/postgres/workflow_run.go
+++ b/pkg/repository/postgres/workflow_run.go
@@ -175,7 +175,7 @@ func (w *workflowRunAPIRepository) ListScheduledWorkflows(ctx context.Context, t
 	return scheduledWorkflows, count, nil
 }
 
-func (w *workflowRunAPIRepository) DeleteScheduledWorkflow(ctx context.Context, tenantId, scheduledWorkflowId string) error {
+func (w *sharedRepository) DeleteScheduledWorkflow(ctx context.Context, tenantId, scheduledWorkflowId string) error {
 	return w.queries.DeleteScheduledWorkflow(ctx, w.pool, sqlchelpers.UUIDFromStr(scheduledWorkflowId))
 }
 

--- a/pkg/repository/workflow_run.go
+++ b/pkg/repository/workflow_run.go
@@ -541,6 +541,8 @@ type WorkflowRunEngineRepository interface {
 	// GetWorkflowRunById returns a workflow run by id.
 	GetWorkflowRunById(ctx context.Context, tenantId, runId string) (*dbsqlc.GetWorkflowRunRow, error)
 
+	DeleteScheduledWorkflow(ctx context.Context, tenantId, scheduledWorkflowId string) error
+
 	// TODO maybe we don't need this?
 	GetWorkflowRunByIds(ctx context.Context, tenantId string, runId []string) ([]*dbsqlc.GetWorkflowRunRow, error)
 


### PR DESCRIPTION
# Description

Adds support for cron and scheduled workflows to the v1 backend.

NOTE: unlike the previous implementation, we're deleting the `ScheduledRef` row after we trigger the workflow, so it won't show up in the UI after its been triggered. We'll need to decide how to approach this once we integrate the workflow triggers with the OLAP repository.

## Type of change

- [X] New feature (non-breaking change which adds functionality)