### PR TITLE
feat: manual slot release

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250224171706_v1_0_0.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250224171706_v1_0_0.sql
@@ -295,14 +295,14 @@ CREATE TABLE v1_task_runtime (
     task_id bigint NOT NULL,
     task_inserted_at TIMESTAMPTZ NOT NULL,
     retry_count INTEGER NOT NULL,
-    worker_id UUID NOT NULL,
+    worker_id UUID,
     tenant_id UUID NOT NULL,
     timeout_at TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT v1_task_runtime_pkey PRIMARY KEY (task_id, task_inserted_at, retry_count)
 );
 
-CREATE INDEX v1_task_runtime_tenantId_workerId_idx ON v1_task_runtime (tenant_id ASC, worker_id ASC);
+CREATE INDEX v1_task_runtime_tenantId_workerId_idx ON v1_task_runtime (tenant_id ASC, worker_id ASC) WHERE worker_id IS NOT NULL;
 
 CREATE INDEX v1_task_runtime_tenantId_timeoutAt_idx ON v1_task_runtime (tenant_id ASC, timeout_at ASC);
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -578,6 +578,18 @@ func (s *DispatcherImpl) Heartbeat(ctx context.Context, req *contracts.Heartbeat
 
 func (s *DispatcherImpl) ReleaseSlot(ctx context.Context, req *contracts.ReleaseSlotRequest) (*contracts.ReleaseSlotResponse, error) {
 	tenant := ctx.Value("tenant").(*dbsqlc.Tenant)
+
+	switch tenant.Version {
+	case dbsqlc.TenantMajorEngineVersionV0:
+		return s.releaseSlotV0(ctx, tenant, req)
+	case dbsqlc.TenantMajorEngineVersionV1:
+		return s.releaseSlotV1(ctx, tenant, req)
+	default:
+		return nil, status.Errorf(codes.Unimplemented, "ReleaseSlot is not implemented in engine version %s", string(tenant.Version))
+	}
+}
+
+func (s *DispatcherImpl) releaseSlotV0(ctx context.Context, tenant *dbsqlc.Tenant, req *contracts.ReleaseSlotRequest) (*contracts.ReleaseSlotResponse, error) {
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
 	if req.StepRunId == "" {

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -433,7 +433,7 @@ func (d *DispatcherImpl) releaseSlotV1(ctx context.Context, tenant *dbsqlc.Tenan
 	msg, err := tasktypes.MonitoringEventMessageFromInternal(
 		tenantId,
 		tasktypes.CreateMonitoringEventPayload{
-			TaskId:         releasedSlot.ID,
+			TaskId:         releasedSlot.TaskID,
 			RetryCount:     releasedSlot.RetryCount,
 			WorkerId:       &workerId,
 			EventTimestamp: time.Now(),

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -860,3 +860,42 @@ WHERE
     (v1_task_runtime.task_id, v1_task_runtime.task_inserted_at, v1_task_runtime.retry_count) IN (SELECT id, inserted_at, retry_count FROM task)
 RETURNING
     v1_task_runtime.*;
+
+-- name: ManualSlotRelease :one
+WITH task AS (
+    SELECT
+        t.id,
+        t.inserted_at,
+        t.retry_count,
+        t.tenant_id
+    FROM
+        v1_lookup_table lt
+    JOIN
+        v1_task t ON t.id = lt.task_id AND t.inserted_at = lt.inserted_at
+    WHERE
+        lt.external_id = @externalId::uuid AND
+        lt.tenant_id = @tenantId::uuid
+), locked_runtime AS (
+    SELECT
+        tr.task_id,
+        tr.task_inserted_at,
+        tr.retry_count,
+        tr.worker_id
+    FROM
+        v1_task_runtime tr
+    WHERE
+        (tr.task_id, tr.task_inserted_at, tr.retry_count) IN (SELECT id, inserted_at, retry_count FROM task)
+    ORDER BY
+        task_id, task_inserted_at, retry_count
+    FOR UPDATE
+)
+UPDATE
+    v1_task_runtime
+SET
+    worker_id = NULL
+FROM
+    task
+WHERE
+    (v1_task_runtime.task_id, v1_task_runtime.task_inserted_at, v1_task_runtime.retry_count) IN (SELECT id, inserted_at, retry_count FROM task)
+RETURNING
+    v1_task_runtime.*;

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -1187,6 +1187,65 @@ func (q *Queries) LookupExternalIds(ctx context.Context, db DBTX, arg LookupExte
 	return items, nil
 }
 
+const manualSlotRelease = `-- name: ManualSlotRelease :one
+WITH task AS (
+    SELECT
+        t.id,
+        t.inserted_at,
+        t.retry_count,
+        t.tenant_id
+    FROM
+        v1_lookup_table lt
+    JOIN
+        v1_task t ON t.id = lt.task_id AND t.inserted_at = lt.inserted_at
+    WHERE
+        lt.external_id = $1::uuid AND
+        lt.tenant_id = $2::uuid
+), locked_runtime AS (
+    SELECT
+        tr.task_id,
+        tr.task_inserted_at,
+        tr.retry_count,
+        tr.worker_id
+    FROM
+        v1_task_runtime tr
+    WHERE
+        (tr.task_id, tr.task_inserted_at, tr.retry_count) IN (SELECT id, inserted_at, retry_count FROM task)
+    ORDER BY
+        task_id, task_inserted_at, retry_count
+    FOR UPDATE
+)
+UPDATE
+    v1_task_runtime
+SET
+    worker_id = NULL
+FROM
+    task
+WHERE
+    (v1_task_runtime.task_id, v1_task_runtime.task_inserted_at, v1_task_runtime.retry_count) IN (SELECT id, inserted_at, retry_count FROM task)
+RETURNING
+    v1_task_runtime.task_id, v1_task_runtime.task_inserted_at, v1_task_runtime.retry_count, v1_task_runtime.worker_id, v1_task_runtime.tenant_id, v1_task_runtime.timeout_at
+`
+
+type ManualSlotReleaseParams struct {
+	Externalid pgtype.UUID `json:"externalid"`
+	Tenantid   pgtype.UUID `json:"tenantid"`
+}
+
+func (q *Queries) ManualSlotRelease(ctx context.Context, db DBTX, arg ManualSlotReleaseParams) (*V1TaskRuntime, error) {
+	row := db.QueryRow(ctx, manualSlotRelease, arg.Externalid, arg.Tenantid)
+	var i V1TaskRuntime
+	err := row.Scan(
+		&i.TaskID,
+		&i.TaskInsertedAt,
+		&i.RetryCount,
+		&i.WorkerID,
+		&i.TenantID,
+		&i.TimeoutAt,
+	)
+	return &i, err
+}
+
 const preflightCheckDAGsForReplay = `-- name: PreflightCheckDAGsForReplay :many
 WITH dags_to_step_counts AS (
     SELECT

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -204,7 +204,7 @@ type TaskRepository interface {
 
 	RefreshTimeoutBy(ctx context.Context, tenantId string, opt RefreshTimeoutBy) (*sqlcv1.V1TaskRuntime, error)
 
-	ReleaseSlot(ctx context.Context, tenantId string, externalId string) (*sqlcv1.ReleaseTasksRow, error)
+	ReleaseSlot(ctx context.Context, tenantId string, externalId string) (*sqlcv1.V1TaskRuntime, error)
 }
 
 type TaskRepositoryImpl struct {
@@ -1257,7 +1257,7 @@ func (r *TaskRepositoryImpl) RefreshTimeoutBy(ctx context.Context, tenantId stri
 	return res, nil
 }
 
-func (r *TaskRepositoryImpl) ReleaseSlot(ctx context.Context, tenantId, externalId string) (*sqlcv1.ReleaseTasksRow, error) {
+func (r *TaskRepositoryImpl) ReleaseSlot(ctx context.Context, tenantId, externalId string) (*sqlcv1.V1TaskRuntime, error) {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
 
 	if err != nil {
@@ -1266,21 +1266,14 @@ func (r *TaskRepositoryImpl) ReleaseSlot(ctx context.Context, tenantId, external
 
 	defer rollback()
 
-	// get the task by its external id
-	task, err := r.GetTaskByExternalId(ctx, tenantId, externalId, true)
-
-	if err != nil {
-		return nil, err
-	}
-
-	// release the slot
-	resp, err := r.releaseTasks(ctx, tx, tenantId, []TaskIdInsertedAtRetryCount{
-		{
-			Id:         task.ID,
-			InsertedAt: task.InsertedAt,
-			RetryCount: task.RetryCount,
+	resp, err := r.queries.ManualSlotRelease(
+		ctx,
+		tx,
+		sqlcv1.ManualSlotReleaseParams{
+			Tenantid:   sqlchelpers.UUIDFromStr(tenantId),
+			Externalid: sqlchelpers.UUIDFromStr(externalId),
 		},
-	})
+	)
 
 	if err != nil {
 		return nil, err
@@ -1290,11 +1283,7 @@ func (r *TaskRepositoryImpl) ReleaseSlot(ctx context.Context, tenantId, external
 		return nil, err
 	}
 
-	if len(resp) != 1 {
-		return nil, fmt.Errorf("failed to release task")
-	}
-
-	return resp[0], nil
+	return resp, nil
 }
 
 func (r *sharedRepository) releaseTasks(ctx context.Context, tx sqlcv1.DBTX, tenantId string, tasks []TaskIdInsertedAtRetryCount) ([]*sqlcv1.ReleaseTasksRow, error) {

--- a/sql/schema/v1.sql
+++ b/sql/schema/v1.sql
@@ -293,14 +293,14 @@ CREATE TABLE v1_task_runtime (
     task_id bigint NOT NULL,
     task_inserted_at TIMESTAMPTZ NOT NULL,
     retry_count INTEGER NOT NULL,
-    worker_id UUID NOT NULL,
+    worker_id UUID,
     tenant_id UUID NOT NULL,
     timeout_at TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT v1_task_runtime_pkey PRIMARY KEY (task_id, task_inserted_at, retry_count)
 );
 
-CREATE INDEX v1_task_runtime_tenantId_workerId_idx ON v1_task_runtime (tenant_id ASC, worker_id ASC);
+CREATE INDEX v1_task_runtime_tenantId_workerId_idx ON v1_task_runtime (tenant_id ASC, worker_id ASC) WHERE worker_id IS NOT NULL;
 
 CREATE INDEX v1_task_runtime_tenantId_timeoutAt_idx ON v1_task_runtime (tenant_id ASC, timeout_at ASC);
 


### PR DESCRIPTION
# Description

Adds support for manual slot releases to the v1 engine. 

NOTE: this also fixes an issue on the old engine where a slot release could case a workflow run to end up in a `RUNNING` state forever since we were not only deleting semaphore queue items, but also timeout queue items. In this case, we're setting the `worker_id` column on the `v1_task_runtime` to `NULL`, which means that timeouts will still be processed, but we won't count it towards a slot on the worker. This should be more expected/stable behavior. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)