### PR TITLE
fix: support webhook workers

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250224171706_v1_0_0.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250224171706_v1_0_0.sql
@@ -603,7 +603,8 @@ BEGIN
         tenant_id,
         id,
         inserted_at
-    FROM new_table;
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
 
     RETURN NULL;
 END;
@@ -1025,7 +1026,8 @@ BEGIN
         tenant_id,
         id,
         inserted_at
-    FROM new_table;
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
 
     RETURN NULL;
 END;
@@ -1454,7 +1456,8 @@ BEGIN
         external_id,
         id,
         inserted_at
-    FROM new_rows;
+    FROM new_rows
+    ON CONFLICT (external_id) DO NOTHING;
 
     -- If the task has a dag_id and dag_inserted_at, insert into the lookup table
     INSERT INTO v1_dag_to_task_olap (
@@ -1560,7 +1563,8 @@ BEGIN
         external_id,
         id,
         inserted_at
-    FROM new_rows;
+    FROM new_rows
+    ON CONFLICT (external_id) DO NOTHING;
 
     RETURN NULL;
 END;

--- a/internal/services/shared/tasktypes/v1/olap.go
+++ b/internal/services/shared/tasktypes/v1/olap.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	msgqueue "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
@@ -57,10 +59,16 @@ type CreateMonitoringEventPayload struct {
 }
 
 func MonitoringEventMessageFromActionEvent(tenantId string, taskId int64, retryCount int32, request *contracts.StepActionEvent) (*msgqueue.Message, error) {
+	var workerId *string
+
+	if _, err := uuid.Parse(request.WorkerId); err == nil {
+		workerId = &request.WorkerId
+	}
+
 	payload := CreateMonitoringEventPayload{
 		TaskId:         taskId,
 		RetryCount:     retryCount,
-		WorkerId:       &request.WorkerId,
+		WorkerId:       workerId,
 		EventTimestamp: request.EventTimestamp.AsTime(),
 		EventPayload:   request.EventPayload,
 	}

--- a/pkg/repository/v1/match.go
+++ b/pkg/repository/v1/match.go
@@ -534,7 +534,6 @@ func (m *sharedRepository) createEventMatches(ctx context.Context, tx sqlcv1.DBT
 			triggerStepIds = append(triggerStepIds, sqlchelpers.UUIDFromStr(*match.TriggerStepId))
 			triggerStepIndices = append(triggerStepIndices, match.TriggerStepIndex.Int64)
 			triggerExternalIds = append(triggerExternalIds, sqlchelpers.UUIDFromStr(*match.TriggerExternalId))
-			triggerWorkflowRunIds = append(triggerWorkflowRunIds, sqlchelpers.UUIDFromStr(*match.TriggerWorkflowRunId))
 			triggerParentExternalIds = append(triggerParentExternalIds, match.TriggerParentTaskExternalId)
 			triggerParentTaskIds = append(triggerParentTaskIds, match.TriggerParentTaskId)
 			triggerParentTaskInsertedAts = append(triggerParentTaskInsertedAts, match.TriggerParentTaskInsertedAt)
@@ -545,6 +544,12 @@ func (m *sharedRepository) createEventMatches(ctx context.Context, tx sqlcv1.DBT
 				triggerExistingTaskIds = append(triggerExistingTaskIds, pgtype.Int8{Int64: *match.TriggerExistingTaskId, Valid: true})
 			} else {
 				triggerExistingTaskIds = append(triggerExistingTaskIds, pgtype.Int8{})
+			}
+
+			if match.TriggerWorkflowRunId != nil {
+				triggerWorkflowRunIds = append(triggerWorkflowRunIds, sqlchelpers.UUIDFromStr(*match.TriggerWorkflowRunId))
+			} else {
+				triggerWorkflowRunIds = append(triggerWorkflowRunIds, pgtype.UUID{})
 			}
 
 			triggerExistingTaskInsertedAts = append(triggerExistingTaskInsertedAts, match.TriggerExistingTaskInsertedAt)

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -448,7 +448,7 @@ func (r *TaskRepositoryImpl) GetTaskByExternalId(ctx context.Context, tenantId, 
 	}
 
 	if len(dbTasks) > 1 {
-		return nil, errors.New("found more than one task")
+		return nil, fmt.Errorf("found more than one task for %s", taskExternalId)
 	}
 
 	// set the cache

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -588,7 +588,7 @@ func (r *TriggerRepositoryImpl) triggerWorkflows(ctx context.Context, tenantId s
 				eventMatches[tuple.externalId] = append(eventMatches[tuple.externalId], CreateMatchOpts{
 					Kind:                 sqlcv1.V1MatchKindTRIGGER,
 					Conditions:           conditions,
-					TriggerExternalId:    &tupleExternalId,
+					TriggerExternalId:    &taskExternalId,
 					TriggerWorkflowRunId: &tupleExternalId,
 					TriggerStepId:        &stepId,
 					TriggerStepIndex: pgtype.Int8{

--- a/sql/schema/v1.sql
+++ b/sql/schema/v1.sql
@@ -601,7 +601,8 @@ BEGIN
         tenant_id,
         id,
         inserted_at
-    FROM new_table;
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
 
     RETURN NULL;
 END;
@@ -1023,7 +1024,8 @@ BEGIN
         tenant_id,
         id,
         inserted_at
-    FROM new_table;
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
 
     RETURN NULL;
 END;
@@ -1452,7 +1454,8 @@ BEGIN
         external_id,
         id,
         inserted_at
-    FROM new_rows;
+    FROM new_rows
+    ON CONFLICT (external_id) DO NOTHING;
 
     -- If the task has a dag_id and dag_inserted_at, insert into the lookup table
     INSERT INTO v1_dag_to_task_olap (
@@ -1558,7 +1561,8 @@ BEGIN
         external_id,
         id,
         inserted_at
-    FROM new_rows;
+    FROM new_rows
+    ON CONFLICT (external_id) DO NOTHING;
 
     RETURN NULL;
 END;


### PR DESCRIPTION
# Description

Fixes a parse error on OLAP events which were preventing webhook worker-triggered runs from completing in the UI. 

Also fixes an issue where the external ID for a child task in a DAG wasn't being set to the proper value, causing a collision on external ids which was preventing DAGs from executing properly.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)